### PR TITLE
Update href to support opening in new tab

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -116,7 +116,16 @@ export const href = (href: string, router: Router | undefined = defaultRouter) =
   }
   return {
     href,
-    onClick: (ev: Event) => {
+    onClick: (ev: MouseEvent) => {
+      console.log('Router href on click', ev);
+      if (ev.metaKey || ev.ctrlKey) {
+        return;
+      }
+
+      if (ev.which == 2 || ev.button == 4) {
+        return;
+      }
+
       ev.preventDefault();
       router.push(href);
     },

--- a/src/router.ts
+++ b/src/router.ts
@@ -117,12 +117,11 @@ export const href = (href: string, router: Router | undefined = defaultRouter) =
   return {
     href,
     onClick: (ev: MouseEvent) => {
-      console.log('Router href on click', ev);
       if (ev.metaKey || ev.ctrlKey) {
         return;
       }
 
-      if (ev.which == 2 || ev.button == 4) {
+      if (ev.which == 2 || ev.button == 1) {
         return;
       }
 


### PR DESCRIPTION
Currently `href` always prevents the default click action. This adds support to make sure command/ctrl clicking and middle mouse button clicking open the link in a new tab.